### PR TITLE
add ability to pop lines from input content

### DIFF
--- a/aoc/__init__.py
+++ b/aoc/__init__.py
@@ -1,2 +1,1 @@
-from aoc.reformaters import combine_nonblank_lines
-from aoc.solution import Solution
+from aoc.solution import Solution  # noqa: F401

--- a/aoc/helpers.py
+++ b/aoc/helpers.py
@@ -18,7 +18,10 @@ def read_asset(asset_name: str) -> str:
 
 
 def get_latest_year() -> int:
-    """Returns the last year if we are not in december yet otherwise returns the current year."""
+    """
+    Returns the last year if we are not in december yet otherwise
+    returns the current year.
+    """
     today = datetime.now()
     if today.month < 12:
         return today.year - 1

--- a/aoc/input_handler.py
+++ b/aoc/input_handler.py
@@ -2,6 +2,11 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 
+from mypy_extensions import KwArg
+
+MutateFunction = Callable[[str, KwArg()], Any]
+FormatterFunction = Callable[[list[str], KwArg()], list[str]]
+
 
 class InputHandler:
     """Class to reformat and mutate input data"""
@@ -13,16 +18,17 @@ class InputHandler:
     def content(self) -> list[str]:
         return self.__content
 
+    def pop_line(self) -> str:
+        return self.__content.pop(0)
+
     def as_list(
-        self,
-        mutate: Optional[Callable[[str, Any], Any]] = None,
-        **kwargs: Optional[Any]
+        self, mutate: Optional[MutateFunction] = None, **kwargs: Any
     ) -> list[Any]:
         """Mutate each element in the input list
 
         Parameters
         ----------
-        mutate : Optional[Callable], optional
+        mutate : Callable[[str, ...], Any], optional
             A function to apply to each element, by default None
 
         Returns
@@ -31,26 +37,24 @@ class InputHandler:
             The mutated data
         """
         if not mutate:
-            mutate = str.strip
+            return self.content
 
-        return [mutate(x, **kwargs) for x in self.content]  # type: ignore
+        return [mutate(x, **kwargs) for x in self.content]
 
-    def reformat(
-        self, formater: Callable[[list[str], Any], list[str]], **kwargs: Optional[Any]
-    ) -> None:
+    def reformat(self, formater: FormatterFunction, **kwargs: Optional[Any]) -> None:
         """Change the format of the input data
 
         You might want to do this if the original list of strings from the input data
-        doesn't lend itself to the desired format. For example, if the input data is has groups
-        of lines that should be together, but are seperated by newlines, you can reformat the data
-        to make each group a single element in the list.
+        doesn't lend itself to the desired format. For example, if the input data is
+        has groups of lines that should be together, but are seperated by newlines,
+        you can reformat the data to make each group a single element in the list.
 
         See `aoc.reformaters`
 
         Parameters
         ----------
-        formater : Callable
+        formater : Callable[[list[str], ...], list[str]]
             A function that takes a list of strings and returns a new list of strings.
         """
         if self.__content:
-            self.__content = formater(self.content, **kwargs)  # type: ignore
+            self.__content = formater(self.content, **kwargs)

--- a/aoc/solution.py
+++ b/aoc/solution.py
@@ -96,6 +96,7 @@ class Solution(ABC):
             The input data as a list of strings.
         """
         self.input = InputHandler(input_data)
+        self._pop_lines()
         self._reformat_data()
 
     def part_one(self) -> int:
@@ -125,6 +126,9 @@ class Solution(ABC):
     @abstractmethod
     def _part_two(self) -> int:
         """Implement part two solution here"""
+
+    def _pop_lines(self) -> None:
+        """Remove lines from the beginning of the input data, before any reformatting"""
 
     def _reformat_data(self) -> None:
         """Change how the input data is formatted BEFORE any mutations."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 black==19.10b0
 click==8.0.3
+coverage
+flake8
 mypy==0.910
 pre-commit
-pylint==2.9.6
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,9 @@ exclude =
 console_scripts =
     aoc = aoc.scripts.aoc:cli
 
+[flake8]
+max-line-length = 100
+
 [mypy]
 check_untyped_defs = true
 disallow_any_generics = true
@@ -39,3 +42,11 @@ disallow_untyped_defs = true
 no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+
+[mypy-testing.*]
+disallow_untyped_defs = false
+ignore_missing_imports = True
+
+[mypy-tests.*]
+disallow_untyped_defs = false
+ignore_missing_imports = True

--- a/testing/mixins.py
+++ b/testing/mixins.py
@@ -1,0 +1,11 @@
+class BlankSolutionPartMixin:
+    """
+    Add this when you want to satisfy the ABC requirements of
+    the solution class but don't care about the actual part functions
+    """
+
+    def _part_one(self) -> int:
+        return 1
+
+    def _part_two(self) -> int:
+        return 1

--- a/tests/test_input_handler.py
+++ b/tests/test_input_handler.py
@@ -1,0 +1,27 @@
+from aoc.input_handler import InputHandler
+
+
+def test_pop_line() -> None:
+    """Test that pop_line removes the first element from content"""
+    data = ["A", "B", "C", "D"]
+    ih = InputHandler(data)
+
+    first_line = ih.pop_line()
+    assert first_line == "A"
+    assert ih.content == ["B", "C", "D"]
+
+
+def test_as_list_no_mutatations() -> None:
+    """Test that as_list with no mutate arg returns the data"""
+    data = ["A", "B", "C", "D"]
+    ih = InputHandler(data)
+
+    assert ih.as_list() == data
+
+
+def test_as_list_int_mutation() -> None:
+    """Test that as_list with mutate=int returns a list of ints"""
+    data = ["1", "2", "3", "4"]
+    ih = InputHandler(data)
+
+    assert ih.as_list(mutate=int) == [1, 2, 3, 4]

--- a/tests/test_solution/test_pop_lines.py
+++ b/tests/test_solution/test_pop_lines.py
@@ -1,0 +1,46 @@
+from aoc import Solution
+from testing.mixins import BlankSolutionPartMixin
+
+
+class Solution1(BlankSolutionPartMixin, Solution):
+    first_line: str
+
+    def __init__(self) -> None:
+        super().__init__(0, 0, "")
+
+    def _pop_lines(self) -> None:
+        self.first_line = self.input.pop_line()
+
+
+class Solution2(BlankSolutionPartMixin, Solution):
+    first_line: str
+
+    def __init__(self) -> None:
+        super().__init__(0, 0, "")
+
+    def _pop_lines(self) -> None:
+        self.first_line = self.input.pop_line()
+
+    def _reformat_data(self) -> None:
+        def reformatter(content: list[str]) -> list[str]:
+            return ["".join(content)]
+
+        self.input.reformat(reformatter)  # type: ignore
+
+
+def test_pop_lines() -> None:
+    data = ["A", "B", "C", "D"]
+    s = Solution1()
+    s.set_input_data(data)
+
+    assert s.first_line == "A"
+    assert s.input.content == ["B", "C", "D"]
+
+
+def test_pop_lines_with_reformat() -> None:
+    data = ["A", "B", "C", "D"]
+    s = Solution2()
+    s.set_input_data(data)
+
+    assert s.first_line == "A"
+    assert s.input.content == ["BCD"]


### PR DESCRIPTION
add `_pop_line` function to `Solution`. 

Use this function to pop off lines from the input reader's content and process them separately. `_reformat_data` is run after any lines are popped. 