### PR TITLE
Download input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 inputs/
 input.txt
 docs/_html
+test_dir/
+.aoc_cache/
 
 .DS_Store
 *.vscode*

--- a/aoc/input_manager.py
+++ b/aoc/input_manager.py
@@ -1,0 +1,32 @@
+import pathlib
+import urllib.request
+
+
+class InputManager:
+    def __init__(self, year: int, day: int):
+        self.year = year
+        self.day = day
+
+        self.cache_dir = pathlib.Path(".aoc_cache")
+        self.cache_dir.mkdir(exist_ok=True)
+
+        self.cache_file = self.cache_dir / f"{year}-{day:02}.txt"
+
+    def create_input_file(self) -> None:
+        if self.cache_file.exists():
+            print(f"Using cached input file: ./{self.cache_file}")
+            data = self.cache_file.read_text()
+        else:
+            print("Fetching input file from adventofcode.com!")
+            data = self.__make_request()
+            self.cache_file.write_text(data)
+
+        pathlib.Path("input.txt").write_text(data)
+
+    def __make_request(self) -> str:
+        session_cookie = pathlib.Path(".env").read_text().strip()
+        session_header = {"Cookie": f"session={session_cookie}"}
+        url = f"https://adventofcode.com/{self.year}/day/{self.day}/input"
+
+        req = urllib.request.Request(url, headers=session_header)
+        return urllib.request.urlopen(req).read().decode()

--- a/aoc/input_manager.py
+++ b/aoc/input_manager.py
@@ -1,5 +1,6 @@
 import pathlib
-import urllib.request
+
+import requests
 
 
 class InputManager:
@@ -28,5 +29,4 @@ class InputManager:
         session_header = {"Cookie": f"session={session_cookie}"}
         url = f"https://adventofcode.com/{self.year}/day/{self.day}/input"
 
-        req = urllib.request.Request(url, headers=session_header)
-        return urllib.request.urlopen(req).read().decode()
+        return requests.get(url, headers=session_header).text

--- a/aoc/scripts/aoc.py
+++ b/aoc/scripts/aoc.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 from typing import Optional
 
@@ -7,6 +6,7 @@ import click
 from aoc.helpers import display_solution
 from aoc.helpers import get_latest_year
 from aoc.helpers import instantiate_solution
+from aoc.input_manager import InputManager
 from aoc.solution_manager import SolutionManager
 
 
@@ -18,14 +18,9 @@ def cli() -> None:
 @cli.command()
 def init() -> None:
     """Initialize a new solution folder"""
-    curdir = pathlib.Path(os.getcwd())
-
-    if os.listdir(curdir):
-        click.echo("Please run this command from an empty directory")
-        return
-
     pathlib.Path("input.txt").touch()
     pathlib.Path("requirements.txt").touch()
+    pathlib.Path(".env").touch()
 
 
 @cli.command()
@@ -35,6 +30,7 @@ def init() -> None:
 @click.option("--number", "-n", "number", type=int, default=1000)
 @click.option("-i", "input_file", type=str, default="input.txt")
 @click.option("-s", "solution_file", type=str, default=None)
+@click.option("--pull", is_flag=True, default=False)
 def run(
     day: int,
     year: int,
@@ -42,6 +38,7 @@ def run(
     number: int,
     input_file: str,
     solution_file: Optional[str],
+    pull: bool,
 ) -> None:
     """Run a solution file"""
     if not input_file:
@@ -50,6 +47,9 @@ def run(
 
     if not solution_file:
         solution_file = f"{year}/day{day:02}.py"
+
+    if pull:
+        InputManager(year, day).create_input_file()
 
     input_path = pathlib.Path(input_file)
     solution_path = pathlib.Path(solution_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 black==19.10b0
 click==8.0.3
-coverage
-flake8
+coverage==6.2
+flake8==4.0.1
 mypy==0.910
-pre-commit
-pytest
-tox
+pre-commit==2.16.0
+pytest==6.2.5
+requests==2.26.0
+responses==0.16.0
+tox==3.24.4
+types-requests==2.26.1

--- a/tests/test_input_manger.py
+++ b/tests/test_input_manger.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import responses
+
+from aoc.input_manager import InputManager
+
+TEST_URL = "https://adventofcode.com/2021/day/1/input"
+
+
+@responses.activate
+def test_download_file_if_no_cache(capsys) -> None:
+    responses.add(responses.GET, TEST_URL, body="1,2,3,4,5", status=200)
+
+    with TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        Path(".env").touch()
+
+        InputManager(2021, 1).create_input_file()
+        assert capsys.readouterr().out.startswith("Fetching input file")
+
+        input_file = Path("input.txt").read_text()
+        assert input_file == "1,2,3,4,5"
+
+
+@responses.activate
+def test_download_file_if_cache(capsys) -> None:
+    responses.add(responses.GET, TEST_URL, body="1,2,3,4,5", status=200)
+
+    with TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        Path(".env").touch()
+
+        cached = Path(".aoc_cache/2021-01.txt")
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        cached.write_text("5,4,3,2,1")
+
+        InputManager(2021, 1).create_input_file()
+        assert capsys.readouterr().out.startswith("Using cached input file")
+
+        input_file = Path("input.txt").read_text()
+        assert input_file == "5,4,3,2,1"


### PR DESCRIPTION
when using `aoc run`, you can use the `--pull` flag to A) download the input file or B) use a cached input file that was previously downloaded. To use this, you have to add you session cookie to the .env file.